### PR TITLE
Correct link and blocks in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 The OD01 is 64x128 dot matrix monochrome OLED screen which has an SSD1306 mounted on to it. 
 Use it with a micro:bit to show large amounts of data on screen at the same time.
  
-![](od01.jpg)
+![](https://raw.githubusercontent.com/xinabox/pxt-OD01/master/od01.jpg)
 
 [Read more about it or purchase one here](https://xinabox.cc/products/od01)
 

--- a/README.md
+++ b/README.md
@@ -86,12 +86,12 @@ basic.forever(function () {
 
 ```blocks
 // Print "Number = " then "42" in the location specified (column = 42, row = 4, color = 1):
-OD01.String("Calling", 42, 4, 1)
-OD01.Number(446, 88, 4, 1)
+OD01.showString("Calling", 42, 4, 1)
+OD01.showNumber(446, 88, 4, 1)
 
 // Print "Calling " then "446" in the same place but inverted (use for emphasis like bold):
-OD01.String("Calling", 42, 4, 0)
-OD01.Number(446, 88, 4, 0)
+OD01.showString("Calling", 42, 4, 0)
+OD01.showNumber(446, 88, 4, 0)
 
 ```
 
@@ -107,11 +107,11 @@ If you wanted to show the score of a game in the top right of the screen you wou
 
 // Now put these together to create a cool blinking effect:
 basic.forever(function () {
-    OD01.String("Calling", 42, 4, 1)
-    OD01.Number(446, 88, 4, 1)
+    OD01.showString("Calling", 42, 4, 1)
+    OD01.showNumber(446, 88, 4, 1)
     basic.pause(500)
-    OD01.String("Calling", 42, 4, 0)
-    OD01.Number(446, 88, 4, 0)
+    OD01.showString("Calling", 42, 4, 0)
+    OD01.showNumber(446, 88, 4, 0)
     basic.pause(500)
 })
 
@@ -126,8 +126,8 @@ To remove text or numbers added using the Show methods use the following techniq
 ```blocks
 
 // Print an empty string to the location you want to remove text / numbers from:
-OD01.String("Calling", 42, 4, 1)
-OD01.String("       ", 42, 4, 1)
+OD01.showString("Calling", 42, 4, 1)
+OD01.showString("       ", 42, 4, 1)
 
 ```
 


### PR DESCRIPTION
* correct image link to work in https://makecode.microbit.org/pkg/xinabox/pxt-OD01
* correct badly rendered "show string" and "show number" blocks:
![image](https://user-images.githubusercontent.com/54072413/108861264-c93e9780-75cd-11eb-836d-b5c7cbade331.png)
